### PR TITLE
Bugfixes and active joints getter.

### DIFF
--- a/api/tap/JsonAdqlBuilder.js
+++ b/api/tap/JsonAdqlBuilder.js
@@ -258,16 +258,13 @@ var JsonAdqlBuilder = (function(){
      * @param {String} table Optional, unqualified name of the node table or the root table if unspecified
      */
     JsonAdqlBuilder.prototype.getAdqlJoints = function(table){
-        
-        let whitelist = this.getSubTables(table);
-        
-        if(whitelist.status){
-            whitelist = whitelist.subTables;
-        }else{
-            return whitelist;
-        }
+        let joints = this.getActiveJoints(table);
 
-        let joints = this.adqlJsonMap.activeJoints.filter(value => whitelist.includes(value));
+        if(joints.status){
+            joints = joints.joints;
+        }else{
+            return joints;
+        }
 
         let adqlJoints = "";
 
@@ -280,6 +277,20 @@ var JsonAdqlBuilder = (function(){
 
         return {"status":true,"adqlJoints":adqlJoints};
 
+    };
+
+    JsonAdqlBuilder.prototype.getActiveJoints = function(table){
+        let whitelist = this.getSubTables(table);
+        
+        if(whitelist.status){
+            whitelist = whitelist.subTables;
+        }else{
+            return whitelist;
+        }
+
+        let joints = this.adqlJsonMap.activeJoints.filter(value => whitelist.includes(value));
+
+        return {"status":true,"joints":joints};
     };
 
     /**

--- a/api/tap/TapApi.js
+++ b/api/tap/TapApi.js
@@ -136,6 +136,14 @@ var TapApi = (function(){
         return jsonContaintJoinTable;
     };
 
+    TapApi.prototype.getActiveJoints = function(table){
+        if (this.getConnector().status) {
+            return this.jsonAdqlBuilder.getActiveJoints(table);
+        } else {
+            return {"logs":"No active TAP connection","prams":{"table":table}};
+        }
+    };
+
     /**
      * DEPRACTED use `getTableFields`
      */

--- a/api/utils/AttributeHolder.js
+++ b/api/utils/AttributeHolder.js
@@ -74,7 +74,6 @@ AttributeHolder = function(queryAble){
         if(queryResult.status){
             let data = queryResultToDoubleArray(queryResult.answer);
             let AHList = doubleArrayToAHList(data);
-            console.log(AHList);
             for (let i=0;i<AHList.length;i++){
                 if(ahMap[AHList[i].table_name.toLowerCase()]!==undefined){
                     ahMap[AHList[i].table_name.toLowerCase()].push(AHList[i]);

--- a/api/utils/AttributeHolder.js
+++ b/api/utils/AttributeHolder.js
@@ -53,28 +53,36 @@ AttributeHolder = function(queryAble){
         let ahMap = {};
         let fName;
         for (let i =0 ;i<tables.length;i++){
-            fName = [schema, tables[i]].join('.').quotedTableName().qualifiedName.toLowerCase();
+            fName = [schema, tables[i]].join('.').quotedTableName().qualifiedName;
             if(cache[fName]!== undefined){
                 ahMap[tables[i].toLowerCase()]=Array.from(cache[fName]);
-                nameMap[tables[i].toLowerCase()]=fName;
+                nameMap[tables[i].toLowerCase()]=fName.toLowerCase();
             }else {
-                fullNames[tables[i].toLowerCase()]=fName;
+                fullNames[tables[i]]=fName;
             }
         }
         let adql = Holder.getAHsAdql(fullNames);
         let queryResult = await queryAble.Query(adql);
-        
+
+        let fuzzyNames = {};
+
+        for(let name in fullNames){
+            fuzzyNames[name.toLowerCase()]= fullNames[name].toLowerCase();
+        }
+        fullNames = fuzzyNames;
+
         if(queryResult.status){
             let data = queryResultToDoubleArray(queryResult.answer);
             let AHList = doubleArrayToAHList(data);
+            console.log(AHList);
             for (let i=0;i<AHList.length;i++){
                 if(ahMap[AHList[i].table_name.toLowerCase()]!==undefined){
                     ahMap[AHList[i].table_name.toLowerCase()].push(AHList[i]);
                 } else if (fullNames[AHList[i].table_name.toLowerCase()] !== undefined){
-                    if(ahMap[fullNames[AHList[i].table_name.toLowerCase()]]===undefined){
-                        ahMap[fullNames[AHList[i].table_name.toLowerCase()]] = [];
+                    if(ahMap[fullNames[AHList[i].table_name.toLowerCase()].toLowerCase()]===undefined){
+                        ahMap[fullNames[AHList[i].table_name.toLowerCase()].toLowerCase()] = [];
                     }
-                    ahMap[fullNames[AHList[i].table_name.toLowerCase()]].push(AHList[i]);
+                    ahMap[fullNames[AHList[i].table_name.toLowerCase()].toLowerCase()].push(AHList[i]);
                 }else if(Object.values(fullNames).includes(AHList[i].table_name.toLowerCase())){
                     ahMap[AHList[i].table_name.toLowerCase()] = [];
                     ahMap[AHList[i].table_name.toLowerCase()].push(AHList[i]);

--- a/demo/html/searchBar.html
+++ b/demo/html/searchBar.html
@@ -1,0 +1,97 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>test of searchBar</title>
+
+        <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+        <script src="https://unpkg.com/@popperjs/core@2.10.2/dist/umd/popper.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/highlight.min.js"></script>
+
+        <!-- Tap Complex API imports -->
+        <script type="text/javascript" src="../../api/utils/jsonRead.js"></script>
+
+        <script type="text/javascript" src="../../api/utils/VOTableTools.js"></script>
+        <script type="text/javascript" src="../../api/utils/util.js"></script>
+        <script type="text/javascript" src="../../api/utils/AttributeHolder.js"></script>
+        <script type="text/javascript" src="../../api/utils/votable.js"></script>
+
+        <script type="text/javascript" src="../../api/tap/TapService.js"></script>
+        <script type="text/javascript" src="../../api/tap/TapApi.js"></script>
+
+        <script type="text/javascript" src="../../api/tap/TapServiceConnector.js"></script>
+        <script type="text/javascript" src="../../api/tap/JsonAdqlBuilder.js"></script>
+        <script type="text/javascript" src="../../api/tap/KnowledgeTank.js"></script>
+
+        <!-- End of Tap Complex API imports -->
+
+        <!-- Custum scripts -->
+
+        <script type="text/javascript" src="../js/shared.js"></script>
+        <script type="text/javascript" src="../js/searchBar.js"></script>
+        
+        <!-- End of Custum scripts -->
+
+        <!-- Imported Scripts -->
+
+        <!-- End of Imported Scripts -->
+            
+        <!-- CSS imports -->
+
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/github.min.css">
+
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+        
+        <link rel="stylesheet" href="../css/style.css">
+        <link href="../css/main.css" rel="stylesheet">
+        <!-- End of CSS imports -->
+
+    </head>
+
+    <body>
+        <div id="overlay">
+            <div class="cv-spinner">
+                <span class="spinner"></span>
+            </div>
+        </div>
+        <div style="display: flex;flex-flow: column;height: 100%;">
+            <!-- Banner -->
+            <div style="display: flex;">
+                <div class="col-2">
+                    <button class="btn btn-primary" style="margin-top: 0.5em;margin-bottom: 0.5em;width: 100%;" id="btnDebug">Show Debug info</button>
+                </div>
+                <div class="col-8" style="display: flex;justify-content: center;align-items: center;">
+                    <input id="searchBar" type="text" autocomplete="off" style="width: 100%;" >
+                </div>
+                <div class="col-2">
+                    <button class="btn btn-primary" style="margin-top: 0.5em;margin-bottom: 0.5em;width: 100%;" id="btnSearch">Search</button>
+                </div>
+            </div>
+            <hr>
+            <div style="display: flex;flex-grow : 1;">
+                <div class="col-1"></div>
+
+                <div class="col-10" style="display: flex;flex-grow : 1; overflow:auto; flex-flow: column;">
+                    <div class="card" id="resultList" style= 'overflow:scroll;width: 100%; height: 30%;'>
+
+                    </div>
+                    <hr>
+                    <div class="card" style="height: 30%;">
+                        <h5 class="card-title text-center">Curent query</h5>
+                        <pre style= 'overflow:scroll;width: 100%;flex-grow: 1;'><code id="querrySend"></code></pre>
+                    </div>
+                    <hr>
+                    <div class="card" style="height: 30%;"> 
+                        <h5 class="card-title text-center">Return object of the last function</h5>
+                        <pre style= 'overflow:scroll;width: 100%;flex-grow: 1;'><code id='codeOutput' style="height: 100%;"></code></pre>
+                    </div>
+
+                </div>
+
+                <div class="col-1"></div>
+            </div>
+
+        </div>
+    </body>
+</html>

--- a/demo/js/ComplexQueryEditor.js
+++ b/demo/js/ComplexQueryEditor.js
@@ -67,9 +67,7 @@ ComplexQueryEditor.prototype.formatCondition = function(operator,operand){
         operator = 'IS NOT NULL';
         operand = '';			
     } else {
-        if ( /^\s*'.*'\s*$/.test(operand)  ) {
-            operand = operand;
-        } else {
+        if(isNaN(operand) || isNaN(parseInt(operand)) || isNaN(+operand)) {
             operand = "'" + operand + "'";
         }
         operator = operator;	

--- a/demo/js/overrides/ComplexQEditor_Mvc.js
+++ b/demo/js/overrides/ComplexQEditor_Mvc.js
@@ -21,7 +21,7 @@ function ComplexQEditor_MvcExtends(){
 				tree.table =  ah.table_name;
 				if(ah.table_name.includes(tree.schema)){
 					tree.table = tree.table.substr(tree.schema.length);
-					tree.table = tree.table.substr(tree.table.indexOf("."));
+					tree.table = tree.table.substr(tree.table.indexOf(".")+1);
 				}
 				tree.tableorg = tree.table;
 				var v = new ComplexKWConstraint_mVc({divId: divKey,

--- a/demo/js/searchBar.js
+++ b/demo/js/searchBar.js
@@ -1,0 +1,167 @@
+"use strict;";
+
+function parseString(str,keyWords,separator){
+    let splitted = [str];
+    let newSplit, partialSplit;
+    let data = {"default":[]};
+    let j,k;
+
+    //splitting the string on all separator to get nice strings to work with
+    // can be optimized but would this worth the time spent ? 
+    for (let i=0;i<keyWords.length;i++){
+        data[keyWords[i]]=[];
+        newSplit = [];
+        for (j=0;j<splitted.length;j++){
+            partialSplit = splitted[j].split(keyWords[i]+separator);
+
+            for(k=1;k<partialSplit.length;k++){
+                partialSplit[k] = keyWords[i]+separator + partialSplit[k].trim();
+            }
+            partialSplit[0] = partialSplit[0].trim();
+            if(partialSplit[0].length<1){
+                partialSplit.shift();
+            }
+            newSplit = newSplit.concat(partialSplit);
+        }
+        splitted = newSplit;
+    }
+    let defaultVal = Array.from(splitted);
+    // sorting all data in a convenient way
+    for (let i=0;i<keyWords.length;i++){
+        for (j=0;j<splitted.length;j++){
+            if(splitted[j].startsWith(keyWords[i]+separator)){
+                defaultVal.remove(splitted[j]);
+                data[keyWords[i]].push(splitted[j].substr(keyWords[i].length+separator.length));
+            }
+        }
+    }
+    data.default = defaultVal;
+
+    return data;
+}
+
+async function setupEventHandlers(){
+    let api = new TapApi();
+    await api.connect({
+        "tapService" : "//dc.zah.uni-heidelberg.de/tap/sync",
+        "schema" : "rr",
+        "table" : "resource",
+        "shortName":"Gavo"
+    });
+
+    // default conditions
+    let defaultConditions ={
+        "cabability":"rr.cabability.standard_id='ivo://ivoa.net/std/tap'",
+        "interface":"rr.interface.intf_type = 'vs:paramhttp'"
+    }; 
+    
+    for (let table in defaultConditions){
+        api.setTableConstraint(table,defaultConditions[table]);
+    }
+
+    function simpleStringMerger(conditions,base){
+        let condition = "";
+        for (let i=0;i<conditions.length;i++){
+            if(condition.length>0){
+                condition += " OR ";
+            }
+            if(conditions[i].indexOf("%")==-1){
+                condition += base + "= " + conditions[i];
+            }else {
+                condition += base + "LIKE " + conditions[i];
+            }
+        }
+        return condition;
+    }
+
+    function multiTableStringMerger(conditions,base){
+        let bases = base.split("::");
+        let mergedConditions=[];
+        for (let i=0;i<bases.length;i++){
+            mergedConditions.push("(" + simpleStringMerger(conditions,bases[i]) + ")");
+        }
+        return mergedConditions.join(" OR ");
+    }
+
+    function simpleStringFormator(str){
+        str=str.replace(/([\"\\])/g, "\\$1");
+        return "'" + str + "'";
+    }
+
+    function lazyStringFormator(str){
+        if (!str.startsWith("%")){
+            str = "%" + str;
+        }
+        if(!str.endsWith("%")){
+            str+="%";
+        }
+        return simpleStringFormator(str);
+    }
+    //ouba ouba c'est lui name: le marsupilami utype: marsupiale url:%terre://amazonie/"hute au marsu"
+
+    
+    /*searchBarName:{tableName,conditionBase,type:("string","number"),transform,merger}
+    * `transform` is a function called on each sub conditions before the merger gets called
+    * `merger` is a function taking an array of (possibly one or more but not empty) condition and the base constraint 
+    * to return a single string which will be use as condition
+    */
+    let allowedFieldsMap = {
+        "name":{tableName:"ressource",conditionBase:"rr.ressource.short_name ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "ivoid":{tableName:"ressource",conditionBase:"rr.ressource.ivoid ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "desc":{tableName:"ressource",conditionBase:"rr.ressource.res_description ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "title":{tableName:"ressource",conditionBase:"rr.ressource.res_title ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "role_ivoid":{tableName:"res_role",conditionBase:"rr.res_role.role_ivoid ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "subject":{tableName:"res_subject",conditionBase:"rr.res_subject.res_subject ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "subject_uat":{tableName:"subject_uat",conditionBase:"rr.subject_uat.uat_concept ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "table_name":{tableName:"res_table",conditionBase:"rr.res_table.table_name ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "table_desc":{tableName:"res_table",conditionBase:"rr.res_table.table_description ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "utype":{tableName:"res_table",conditionBase:"rr.res_table.table_utype ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "url":{tableName:"interface",conditionBase:"rr.interface.access_url ",transform:simpleStringFormator,merger:simpleStringMerger},
+        "default":{
+            tableName:"ressource",
+            conditionBase:"rr.ressource.short_name ::rr.ressource.ivoid ::rr.ressource.res_title ",
+            transform:lazyStringFormator,
+            merger:multiTableStringMerger
+        },
+    };
+
+    function processConditions(conditionMap,fieldMap){
+        let processed = {};
+        let partialProcess;
+        
+        for (let consName in conditionMap){
+            if(conditionMap[consName].length>0){
+                partialProcess=[];
+                if(fieldMap[consName].transform){
+                    for(let i=0;i<conditionMap[consName].length;i++){
+                        partialProcess.push(fieldMap[consName].transform(conditionMap[consName][i]));
+                    }
+                } else {
+                    partialProcess = Array.from(conditionMap[consName]);
+                }
+                if(processed[fieldMap[consName].tableName] === undefined){
+                    processed[fieldMap[consName].tableName]=[];
+                }
+                processed[fieldMap[consName].tableName].push(fieldMap[consName].merger(partialProcess,fieldMap[consName].conditionBase));
+            }
+        }
+        for(let table in processed){
+            processed[table] = processed[table].join(" OR ");
+        }
+        return processed;
+    }
+
+    $("#searchBar").keyup(()=>{
+        let parsedData = parseString($("#searchBar").val(),Object.keys(allowedFieldsMap),":");
+        display(processConditions(parsedData,allowedFieldsMap),"codeOutput") ;
+    });
+
+}
+
+$(document).ready(()=>{
+    syncIt( ()=>{
+        setupEventHandlers();
+    });
+    
+});
+

--- a/demo/js/searchBar.js
+++ b/demo/js/searchBar.js
@@ -52,7 +52,7 @@ async function setupEventHandlers(){
     // default conditions
     let defaultConditions ={
         "capability":"rr.capability.standard_id='ivo://ivoa.net/std/tap'",
-        "interface":"rr.interface.intf_type = 'vs:paramhttp'"
+        "interface":"(rr.interface.intf_type = 'vs:paramhttp' AND rr.interface.url_use ='base')"
     }; 
 
     api.selectField("short_name","resource",false);
@@ -66,7 +66,7 @@ async function setupEventHandlers(){
             if(conditions[i].indexOf("%")==-1){
                 condition += base + "= " + conditions[i];
             }else {
-                condition += base + "LIKE " + conditions[i];
+                condition += "UPPER(" + base + ") LIKE " + conditions[i].toUpperCase();
             }
         }
         return condition;
@@ -161,14 +161,13 @@ async function setupEventHandlers(){
             }
         }
         
-        let select = "SELECT TOP 10 ";
+        let select = "SELECT ";
         for (let field in fields){
             select +=  field + " AS " + fields[field] + ", ";
         }
         return select.substr(0,select.length-2) + " ";
     }
-
-    $("#searchBar").keyup(()=>{
+    $("#searchBar").keyup((event)=>{
         let parsedData = parseString($("#searchBar").val(),Object.keys(allowedFieldsMap),":");
         let allCond = processConditions(parsedData,allowedFieldsMap);
 
@@ -194,6 +193,12 @@ async function setupEventHandlers(){
             query = getSelect(parsedData,allowedFieldsMap) + query.substr(query.toLowerCase().indexOf("from"));
 
             display(query,"querrySend");
+            if(event.originalEvent.keyCode == 13){
+                api.query(query).then((val)=>{
+                    display(val,"codeOutput");
+                });
+            }
+            
         });
     });
 

--- a/demo/js/searchBar.js
+++ b/demo/js/searchBar.js
@@ -1,4 +1,195 @@
 "use strict;";
+/**
+ * 
+ * @param {*} keyWords list of keywords to use when parsing strings
+ * @param {*} separator string putted after the keywords to better differenciate keywords from normal text 
+ * @returns 
+ */
+var stringParser = function(keyWords,separator){
+    if (separator === undefined){
+        separator = ":";
+    }
+
+    var parser = {};
+
+    parser.keyWords = keyWords;
+    parser.separator = separator;
+
+    parser.parseString = function(str){
+        let splitted = [str];
+        let newSplit, partialSplit;
+        let data = {"default":[]};
+        let j,k;
+
+        //splitting the string on all separator to get nice strings to work with
+        // can be optimized but would this worth the time spent ? 
+        for (let i=0;i<parser.keyWords.length;i++){
+            data[parser.keyWords[i]]=[];
+            newSplit = [];
+            for (j=0;j<splitted.length;j++){
+                partialSplit = splitted[j].split(parser.keyWords[i]+parser.separator);
+
+                for(k=1;k<partialSplit.length;k++){
+                    partialSplit[k] = parser.keyWords[i]+parser.separator + partialSplit[k].trim();
+                }
+                partialSplit[0] = partialSplit[0].trim();
+                if(partialSplit[0].length<1){
+                    partialSplit.shift();
+                }
+                newSplit = newSplit.concat(partialSplit);
+            }
+            splitted = newSplit;
+        }
+        let defaultVal = Array.from(splitted);
+        // sorting all data in a convenient way
+        for (let i=0;i<parser.keyWords.length;i++){
+            for (j=0;j<splitted.length;j++){
+                if(splitted[j].startsWith(parser.keyWords[i]+parser.separator)){
+                    defaultVal.remove(splitted[j]);
+                    data[parser.keyWords[i]].push(splitted[j].substr(parser.keyWords[i].length+parser.separator.length));
+                }
+            }
+        }
+        data.default = defaultVal;
+
+        return data;
+    };
+
+    return parser;
+
+};
+
+var dataQueryier = function(api,fieldMap,defaultConditions){
+
+    let publicObject = {};
+    publicObject.defaultConditions = defaultConditions;
+
+    publicObject.processConditions = function(conditionMap){
+        let processed = {};
+        let partialProcess;
+        
+        for (let consName in conditionMap){
+            if(conditionMap[consName].length>0){
+                partialProcess=[];
+                if(fieldMap[consName].transform){
+                    for(let i=0;i<conditionMap[consName].length;i++){
+                        partialProcess.push(fieldMap[consName].transform(conditionMap[consName][i]));
+                    }
+                } else {
+                    partialProcess = Array.from(conditionMap[consName]);
+                }
+                if(processed[fieldMap[consName].tableName] === undefined){
+                    processed[fieldMap[consName].tableName]=[];
+                }
+                processed[fieldMap[consName].tableName].push(fieldMap[consName].merger(partialProcess,fieldMap[consName].conditionBase));
+            }
+        }
+        for(let table in processed){
+            processed[table] = processed[table].join(" OR ");
+        }
+        return processed;
+    };
+
+    publicObject.getSelect = function(conditionMap){
+        let fields = {
+            "rr.resource.res_title":"title",
+            "rr.interface.access_url":"url",
+            "rr.resource.ivoid":"ivoid"
+        };
+        for (let consName in conditionMap){
+            if(conditionMap[consName].length>0 && consName != "default"){
+                fields[fieldsMap[consName].conditionBase] = consName;
+            }
+        }
+        
+        let select = "SELECT ";
+        for (let field in fields){
+            select +=  field + " AS " + fields[field] + ", ";
+        }
+        return select.substr(0,select.length-2) + " ";
+    };
+
+    function arraysToMaps(arrays){
+        let maps = [];
+        let map;
+        for (let i=0;i<arrays.field_values.length;i++){
+            map = {};
+            for(let j=0;j<arrays.field_names.length;j++){
+                map[arrays.field_names[j]] = arrays.field_values[i][j];
+            }
+            maps.push(map);
+        }
+        return maps;
+    }
+
+    publicObject.queryData = function(conditionMap){
+        let allCond = publicObject.processConditions(conditionMap);
+
+        for (let table in publicObject.defaultConditions){
+            if(allCond[table]!== undefined){
+                allCond[table] += " AND ( " + publicObject.defaultConditions[table] + " )";
+            } else {
+                allCond[table] = publicObject.defaultConditions[table];
+            }
+        }
+
+        api.resetAllTableConstraint();
+
+        for (let table in allCond){
+            api.setTableConstraint(table,allCond[table]);
+        }
+
+        display(allCond,"codeOutput");
+
+        return api.getTableQuery("resource").then((val)=>{
+            let query = val.query;
+
+            query = getSelect(conditionMap) + query.substr(query.toLowerCase().indexOf("from"));
+
+            display(query,"querrySend");
+            return api.query(query).then((val)=>{
+                display(val,"codeOutput");
+                return arraysToMaps(val);
+            });
+        });
+    };
+
+    return publicObject;
+
+};
+
+/**
+ * 
+ * @param {*} input jQuery object from where the research string will be collected.
+ * @param {*} output jQuery object where the list will be outputed.
+ * @param {*} parser string parser used to parse the string from the input must have a `parseString` method taking.
+ * a string as argument return type depend on the queryier.
+ * @param {*} queryier queryier use to get the data to build the result list must have a `queryData` (can be async) method taking as argument the object
+ * returned by the parser, the queryier return type is an array of object where each object will be passed to the elemBuilder to build each
+ * element of the list.
+ * @param {*} elemBuilder builder use to create each element of the html output list taking as input a element of the array returned by the queryier.
+ * @param {*} handler handler which may take as argument the same object sent to the elemBuilder, a jQuery object representing
+ * the object which has been clicked and a jQuery EventObject.
+ */
+var searchBar = function(input,output,parser,queryier,elemBuilder,handler){ //TO-DO : use a class
+    output.html("<ul class = '' role='listbox' style='text-align: center; border-radius: 4px;"+
+    "border: 1px solid #aaaaaa;padding:0;margin: 0.5em'> </ul>");
+    let list = $("ul",output);
+
+    input.keyup((event)=>{
+        let parsed = parser.parseString(input.val());
+        if(event.originalEvent.keyCode == 13){
+            let data = queryier.queryData(parsed);
+            for (let i=0;i<data.length;i++){
+                list.append(elemBuilder(data[i]));
+                let last = $(":last-child",list); // the varaiable creation in loop is done on purpose.
+                last.click((event)=>{
+                    handler(data[i],last,event);
+                });
+            }
+        }
+    });
+};
 
 function parseString(str,keyWords,separator){
     let splitted = [str];
@@ -167,6 +358,43 @@ async function setupEventHandlers(){
         }
         return select.substr(0,select.length-2) + " ";
     }
+
+    function arraysToMaps(arrays){
+        let maps = [];
+        let map;
+        for (let i=0;i<arrays.field_values.length;i++){
+            map = {};
+            for(let j=0;j<arrays.field_names.length;j++){
+                map[arrays.field_names[j]] = arrays.field_values[i][j];
+            }
+            maps.push(map);
+        }
+        return maps;
+    }
+
+    function dataToHtmlList(data){
+        let list = "<ul class = '' role='listbox' style='text-align: center; border-radius: 4px;"+
+            "border: 1px solid #aaaaaa;padding:0;margin: 0.5em'>";
+        let dat;
+        let li;
+
+        for (let i =0;i<data.length;i++){
+            dat = $.extend({},data[i]);
+            li= "<li style='border-radius: 4px; margin: 0.5em;" +
+                "border: 1px solid #aaaaaa;background: #ffffff 50% 50%;color: #222222;'>" + 
+                dat.title + "<br><small>" + dat.url + "<br>" + dat.ivoid;
+            delete dat.title;
+            delete dat.url;
+            delete dat.ivoid;
+            for (let field in dat){
+                li += "<br>" + field + " : " + dat[field]; 
+            }
+            li += "</small></li>";
+            list += li;
+        }
+        return list + "</ul>";
+    }
+
     $("#searchBar").keyup((event)=>{
         let parsedData = parseString($("#searchBar").val(),Object.keys(allowedFieldsMap),":");
         let allCond = processConditions(parsedData,allowedFieldsMap);
@@ -196,6 +424,7 @@ async function setupEventHandlers(){
             if(event.originalEvent.keyCode == 13){
                 api.query(query).then((val)=>{
                     display(val,"codeOutput");
+                    $("#resultList").html(dataToHtmlList(arraysToMaps(val)));
                 });
             }
             


### PR DESCRIPTION
- Fixed #48 
- Fixed #50 
- Fixed #52 
- new method : `api.getActiveJoints` return the list of tables which will be joined in case of a query on the the table `table`
- new method : `api.query` run the query `query` on the connected tap service and returns the `field_values` as an array or rows as long as the `field_names` as an array of string representing the columns of the table.
- updated all querying methods to also return `field_names` in addition to `field_values`